### PR TITLE
Add Pluribus to context management tools

### DIFF
--- a/docs/ai-ecosystem/workflow-connectivity.json
+++ b/docs/ai-ecosystem/workflow-connectivity.json
@@ -186,6 +186,17 @@
           "pricing": "Open-source and free to use."
         },
         {
+          "name": "Pluribus",
+          "url": "https://github.com/caioribeiroclw-pixel/pluribus",
+          "description": "Open-source CLI for synchronizing AI context across coding tools and emitting evidence receipts for context drift, handoffs, and sufficiency checks.",
+          "features": [
+            "Syncs shared project context and rules into tool-specific instruction artifacts.",
+            "Supports Claude Code, Cursor, Copilot, Windsurf, Continue, Zed, and OpenClaw workflows.",
+            "Includes npm-runnable demos for context sufficiency and evidence-oriented handoff checks."
+          ],
+          "pricing": "Open-source and free to use."
+        },
+        {
           "name": "Pixeltable",
           "url": "https://github.com/pixeltable/pixeltable",
           "description": "Data infrastructure for AI applications that unifies tabular data and embeddings.",


### PR DESCRIPTION
Adds Pluribus to the AI Ecosystem → Workflow Connectivity → Context management section.

Why it fits this section:
- open-source CLI for keeping shared AI context/rules synchronized across coding tools
- targets Claude Code, Cursor, Copilot, Windsurf, Continue, Zed, and OpenClaw workflows
- includes evidence-oriented checks/receipts for context drift, handoffs, and sufficiency, which complements the repository's context engineering / governance themes

I kept the entry concise and in the same JSON schema as the surrounding tools.