### PR TITLE
Fix invalid JSON escape in ollama-local-basic.ipynb

### DIFF
--- a/ch01/jupyter/ollama-local-basic.ipynb
+++ b/ch01/jupyter/ollama-local-basic.ipynb
@@ -30,11 +30,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Requirement already satisfied: requests in c:\\Users\\boni\\\dev\\context-engineering\\.venv\\Lib\\site-packages (2.33.0)\n",
-      "Requirement already satisfied: charset_normalizer<4,>=2 in c:\\Users\\boni\\\dev\\context-engineering\\.venv\\Lib\\site-packages (from requests) (3.4.6)\n",
-      "Requirement already satisfied: idna<4,>=2.5 in c:\\Users\\boni\\\dev\\context-engineering\\.venv\\Lib\\site-packages (from requests) (3.11)\n",
-      "Requirement already satisfied: urllib3<3,>=1.26 in c:\\Users\\boni\\\dev\\context-engineering\\.venv\\Lib\\site-packages (from requests) (2.6.3)\n",
-      "Requirement already satisfied: certifi>=2023.5.7 in c:\\Users\\boni\\\dev\\context-engineering\\.venv\\Lib\\site-packages (from requests) (2026.2.25)\n"
+      "Requirement already satisfied: requests in c:\\Users\\boni\\dev\\context-engineering\\.venv\\Lib\\site-packages (2.33.0)\n",
+      "Requirement already satisfied: charset_normalizer<4,>=2 in c:\\Users\\boni\\dev\\context-engineering\\.venv\\Lib\\site-packages (from requests) (3.4.6)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in c:\\Users\\boni\\dev\\context-engineering\\.venv\\Lib\\site-packages (from requests) (3.11)\n",
+      "Requirement already satisfied: urllib3<3,>=1.26 in c:\\Users\\boni\\dev\\context-engineering\\.venv\\Lib\\site-packages (from requests) (2.6.3)\n",
+      "Requirement already satisfied: certifi>=2023.5.7 in c:\\Users\\boni\\dev\\context-engineering\\.venv\\Lib\\site-packages (from requests) (2026.2.25)\n"
      ]
     }
    ],


### PR DESCRIPTION
## Problem

`ch01/jupyter/ollama-local-basic.ipynb` cannot be opened in JupyterLab

## Changes

- Fix the escaping in `ch01/jupyter/ollama-local-basic.ipynb`. The cell output now
  renders as the intended path (`c:\Users\boni\dev\...`) and the notebook opens again.